### PR TITLE
fix: removed typos in the script to run the app

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
     "test": "echo 'no server-side tests yet'",
     "codegen": "yarn graphql-codegen",
     "clean": "yarn rimraf dist",
-    "dev": "yarn concurrently 'yarn nodemon' 'tsc --watch --preserveWatchOutput' -n node,ts -c green.bgBlack,white.bgBlue"
+    "dev": "yarn concurrently yarn nodemon\" 'tsc --watch --preserveWatchOutput' -n node,ts -c green.bgBlack,white.bgBlue"
   },
   "dependencies": {
     "@full-stack-ts/client": "*",


### PR DESCRIPTION
there were typos in the concurrently script  that were not working for me, it required me to delete some apostrophes and add some backslashes to run the dev script successfully